### PR TITLE
Add  "moduleResolution": "Node" to tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
     "strict": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "moduleResolution": "Node"
   }
 }


### PR DESCRIPTION
Fixes errors on jest.config.ts.

Follow up of https://github.com/eliflores/coding-katas-typescript/pull/5.